### PR TITLE
Install http module in resty directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ TEST_FILE ?= t
 all: ;
 
 install: all
-	$(INSTALL) -d $(DESTDIR)/$(LUA_LIB_DIR)/resty/http
-	$(INSTALL) lib/resty/*.lua $(DESTDIR)/$(LUA_LIB_DIR)/resty/http/
+	$(INSTALL) -d $(DESTDIR)/$(LUA_LIB_DIR)/resty
+	$(INSTALL) lib/resty/*.lua $(DESTDIR)/$(LUA_LIB_DIR)/resty/
 
 test: all
 	PATH=$(OPENRESTY_PREFIX)/nginx/sbin:$$PATH TEST_NGINX_NO_SHUFFLE=1 prove -I../test-nginx/lib -r $(TEST_FILE)


### PR DESCRIPTION
http_headers module is installed in resty/http directory whereas http
module expect this in resty directory.