### PR TITLE
add rockspec

### DIFF
--- a/lua-resty-http-0.2-0.rockspec
+++ b/lua-resty-http-0.2-0.rockspec
@@ -1,0 +1,23 @@
+package = "lua-resty-http"
+version = "0.2-0"
+source = {
+  url = "https://github.com/DorianGray/lua-resty-http/archive/v0.2.tar.gz",
+  dir = "lua-resty-http-0.2"
+}
+description = {
+  summary = "",
+  detailed = [[
+  ]],
+  homepage = "",
+  license = ""
+}
+dependencies = {
+  "lua >= 5.1",
+}
+build = {
+  type = "builtin",
+  modules = {
+    ["resty.http"] = "lib/resty/http.lua",
+    ["resty.http_headers"] = "lib/resty/http_headers.lua"
+  }
+}


### PR DESCRIPTION
This adds the rockspec I used to deploy lua-resty-http to luarocks under the olivine-labs account. Let me know if you'd like to take over administration of this rock or if I should just make pull requests periodically =)