### PR TITLE
Proxy header names with underscores (_) correctly

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -267,7 +267,7 @@ local function _receive_headers(sock)
             return nil, err
         end
 
-        for key, val in str_gmatch(line, "([%w%-]+)%s*:%s*(.+)") do
+        for key, val in str_gmatch(line, "([%w%-_]+)%s*:%s*(.+)") do
             if headers[key] then
                 if type(headers[key]) ~= "table" then
                     headers[key] = { headers[key] }


### PR DESCRIPTION
Currently if the upstream sends a HTTP header like:
    
    foo_bar_baz: value

lua-resty-http returns this as:
    
    baz: value

I.e. header name is truncated to the part after the last underscore.