### PR TITLE
proxy_response: break loop on ngx.print error.

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -805,7 +805,11 @@ function _M.proxy_response(self, response, chunksize)
         end
 
         if chunk then
-            ngx.print(chunk)
+            local res, err = ngx.print(chunk)
+            if not res then
+                ngx_log(ngx_ERR, err)
+                break
+            end
         end
     until not chunk
 end


### PR DESCRIPTION
ngx.print loop don't stop on errors.