### PR TITLE
Support returning HTTP reason-phrase from responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ The `params` table accepts the following fields:
 When the request is successful, `res` will contain the following fields:
 
 * `status` The status code.
+* `reason` The status reason phrase.
 * `headers` A table of headers. Multiple headers with the same field name will be presented as a table of values.
 * `has_body` A boolean flag indicating if there is a body to be read. 
 * `body_reader` An iterator function for reading the body in a streaming fashion.

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -261,10 +261,10 @@ end
 local function _receive_status(sock)
     local line, err = sock:receive("*l")
     if not line then
-        return nil, nil, err
+        return nil, nil, nil, err
     end
 
-    return tonumber(str_sub(line, 10, 12)), tonumber(str_sub(line, 6, 8))
+    return tonumber(str_sub(line, 10, 12)), tonumber(str_sub(line, 6, 8)), str_sub(line, 14)
 end
 
 
@@ -498,7 +498,7 @@ end
 
 
 local function _handle_continue(sock, body)
-    local status, version, err = _receive_status(sock)
+    local status, version, reason, err = _receive_status(sock)
     if not status then
         return nil, err
     end
@@ -600,7 +600,7 @@ function _M.read_response(self, params)
 
     -- Just read the status as normal.
     if not status then
-        status, version, err = _receive_status(sock)
+        status, version, reason, err = _receive_status(sock)
         if not status then
             return nil, err
         end
@@ -650,6 +650,7 @@ function _M.read_response(self, params)
     else
         return {
             status = status,
+            reason = reason,
             headers = res_headers,
             has_body = has_body,
             body_reader = body_reader,

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -83,7 +83,7 @@ OK
 [warn]
 
 
-=== TEST 3: Status code
+=== TEST 3: Status code and reason phrase
 --- http_config eval: $::HttpConfig
 --- config
     location = /a {
@@ -97,6 +97,7 @@ OK
             }
 
             ngx.status = res.status
+            ngx.say(res.reason)
             ngx.print(res:read_body())
             
             httpc:close()
@@ -111,6 +112,7 @@ OK
 --- request
 GET /a
 --- response_body
+Not Found
 OK
 --- error_code: 404
 --- no_error_log


### PR DESCRIPTION
Currently only the status code is returned and the reason-phrase is discarded.