### PR TITLE
Provides a way to disable adding headers automatically

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -533,7 +533,7 @@ function _M.send_request(self, params)
     end
 
     -- Ensure minimal headers are set
-    if type(body) == 'string' and not headers["Content-Length"] then
+    if type(body) == 'string' and headers["Content-Length"] == nil then
         headers["Content-Length"] = #body
     end
     if not headers["Host"] then


### PR DESCRIPTION
Currently the system adds some headers automatically. I would like to provide a way to disable this behavior by introducing a `disable_auto_headers` boolean param that can be set when requesting a resource.

Also addresses #71.