### PR TITLE
checked in file dist.ini for OPM packaging.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,0 +1,9 @@
+name=lua-resty-http
+abstract=Lua HTTP client cosocket driver for OpenResty/ngx_lua
+author=James Hurst
+is_original=yes
+license=2bsd
+lib_dir=lib
+doc_dir=lib
+repo_link=https://github.com/pintsized/lua-resty-http
+main_module=lib/resty/http.lua


### PR DESCRIPTION
OpenResty now has its own package management system, [OPM](https://github.com/openresty/opm#readme). Let's add dist.ini for uploading to the [opm.openresty.org](https://opm.openresty.org) server :)