### PR TITLE
Optimise headers module

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -280,7 +280,6 @@ local function _receive_status(sock)
 end
 
 
-
 local function _receive_headers(sock)
     local headers = http_headers.new()
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -302,7 +302,7 @@ local function _receive_headers(sock)
         else
             headers[key] = tostring(val)
         end
-    until ngx_re_find(line, "^\\s*$")
+    until ngx_re_find(line, "^\\s*$", "jo")
 
     return headers, nil
 end

--- a/lib/resty/http_headers.lua
+++ b/lib/resty/http_headers.lua
@@ -1,7 +1,7 @@
 local   rawget, rawset, setmetatable =
         rawget, rawset, setmetatable
 
-local str_gsub = string.gsub
+local ngx_re_gsub = ngx.re.gsub
 local str_lower = string.lower
 
 
@@ -27,7 +27,7 @@ function _M.new(self)
         if matched then
             return matched
         else
-            local k_hyphened = str_gsub(k, "_", "-")
+            local k_hyphened = ngx_re_gsub(k, "_", "-")
             local k_normalised = str_lower(k_hyphened)
             return rawget(t, mt.normalised[k_normalised])
         end
@@ -42,7 +42,7 @@ function _M.new(self)
     -- the normalised table to give us the original key, and perorm a rawset().
     mt.__newindex = function(t, k, v)
         -- we support underscore syntax, so always hyphenate.
-        local k_hyphened = str_gsub(k, "_", "-")
+        local k_hyphened = ngx_re_gsub(k, "_", "-")
 
         -- lowercase hyphenated is "normalised"
         local k_normalised = str_lower(k_hyphened)


### PR DESCRIPTION
Includes #83 with some fixes.
Notably using ngx.re.* is generally slower if you don't have `o` and `j` PCRE flags set.

In my testing `ngx.re.match` and `str.gmatch` in `_receive_headers` perform very close to each other.
Using plain Lua string functions in the headers metatable does show a measurable performance improvement.