### PR TITLE
add http proxy support to request_uri()

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,18 @@ Note that calling this instead of `close` is "safe" in that it will conditionall
 
 In case of success, returns `1`. In case of errors, returns `nil, err`. In the case where the conneciton is conditionally closed as described above, returns `2` and the error string `connection must be closed`.
 
+## set_proxy_options
+
+`syntax: httpc:set_proxy_options(opts)`
+
+Configure an http proxy to be used with this client instance. The `opts` is a table that accepts the following fields:
+
+* `http_proxy` - an URI to a proxy server to be used with http requests
+* `https_proxy` - an URI to a proxy server to be used with https requests
+* `no_proxy` - a comma separated list of hosts that should not be proxied.
+
+Note that proxy options are only applied when using the high-level `request_uri()` API.
+
 ## get_reused_times
 
 `syntax: times, err = httpc:get_reused_times()`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Production ready.
 
 * [new](#new)
 * [connect](#connect)
+* [connect_proxy](#connect_proxy)
 * [set_timeout](#set_timeout)
 * [set_timeouts](#set_timeouts)
 * [ssl_handshake](#ssl_handshake)
@@ -158,6 +159,24 @@ An optional Lua table can be specified as the last argument to this method to sp
 * `pool`
 : Specifies a custom name for the connection pool being used. If omitted, then the connection pool name will be generated from the string template `<host>:<port>` or `<unix-socket-path>`.
 
+## connect_proxy
+
+`syntax: ok, err = httpc:connect_proxy(proxy_uri, scheme, host, port)`
+
+Attempts to connect to the web server through the given proxy server. The method accepts the following arguments:
+
+* `proxy_uri` - Full URI of the proxy server to use (e.g. `http://proxy.example.com:3128/`). Note: Only `http` protocol is supported.
+* `scheme` - The protocol to use between the proxy server and the remote host (`http` or `https`). If `https` is specified as the scheme, `connect_proxy()` makes a `CONNECT` request to establish a TCP tunnel to the remote host through the proxy server.
+* `host` - The hostname of the remote host to connect to.
+* `port` - The port of the remote host to connect to.
+
+If an error occurs during the connection attempt, this method returns `nil` with a string describing the error. If the connection was successfully established, the method returns `1`.
+
+There's a few key points to keep in mind when using this api:
+
+* If the scheme is `https`, you need to perform the TLS handshake with the remote server manually using the `ssl_handshake()` method before sending any requests through the proxy tunnel.
+* If the scheme is `http`, you need to ensure that the requests you send through the connections conforms to [RFC 7230](https://tools.ietf.org/html/rfc7230) and especially [Section 5.3.2.](https://tools.ietf.org/html/rfc7230#section-5.3.2) which states that the request target must be in absolute form. In practice, this means that when you use `send_request()`, the `path` must be an absolute URI to the resource (e.g. `http://example.com/index.html` instead of just `/index.html`).
+
 ## set_timeout
 
 `syntax: httpc:set_timeout(time)`
@@ -244,7 +263,7 @@ When the request is successful, `res` will contain the following fields:
 * `status` The status code.
 * `reason` The status reason phrase.
 * `headers` A table of headers. Multiple headers with the same field name will be presented as a table of values.
-* `has_body` A boolean flag indicating if there is a body to be read. 
+* `has_body` A boolean flag indicating if there is a body to be read.
 * `body_reader` An iterator function for reading the body in a streaming fashion.
 * `read_body` A method to read the entire body into a string.
 * `read_trailers` A method to merge any trailers underneath the headers, after reading the body.
@@ -420,7 +439,7 @@ local res, err = httpc:request{
 }
 ```
 
-If `sock` is specified, 
+If `sock` is specified,
 
 # Author
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Production ready.
 * [new](#new)
 * [connect](#connect)
 * [connect_proxy](#connect_proxy)
+* [set_proxy_options](#set_proxy_options)
 * [set_timeout](#set_timeout)
 * [set_timeouts](#set_timeouts)
 * [ssl_handshake](#ssl_handshake)

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -801,7 +801,7 @@ function _M.request_uri(self, uri, params)
     if not params.query then params.query = query end
 
     -- See if we should use a proxy to make this request
-    local proxy_host, proxy_port;
+    local proxy_host, proxy_port
     local proxy_uri = self:get_proxy_uri(scheme, host)
     if proxy_uri then
         local parsed_proxy_uri, err = self:parse_uri(proxy_uri, false)

--- a/t/14-host-header.t
+++ b/t/14-host-header.t
@@ -12,7 +12,7 @@ $ENV{TEST_COVERAGE} ||= 0;
 our $HttpConfig = qq{
     lua_package_path "$pwd/lib/?.lua;/usr/local/share/lua/5.1/?.lua;;";
     error_log logs/error.log debug;
-    resolver 8.8.8.8;
+    resolver 8.8.8.8 ipv6=off;
 
     init_by_lua_block {
         if $ENV{TEST_COVERAGE} == 1 then

--- a/t/14-host-header.t
+++ b/t/14-host-header.t
@@ -165,3 +165,30 @@ GET /a
 [error]
 --- response_body
 Unable to generate a useful Host header for a unix domain socket. Please provide one.
+
+=== TEST 6: Host header is correct when http_proxy is used
+--- http_config
+    lua_package_path "$TEST_NGINX_PWD/lib/?.lua;;";
+    error_log logs/error.log debug;
+    resolver 8.8.8.8;
+    server {
+        listen *:8080;
+    }
+
+--- config
+    location /lua {
+        content_by_lua '
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:set_proxy_options({
+                http_proxy = "http://127.0.0.1:8080"
+            })
+            local res, err = httpc:request_uri("http://127.0.0.1:8081")
+        ';
+    }
+--- request
+GET /lua
+--- no_error_log
+[error]
+--- error_log
+Host: 127.0.0.1:8081

--- a/t/16-http-proxy.t
+++ b/t/16-http-proxy.t
@@ -279,10 +279,8 @@ GET /lua
         }
     }
 --- tcp_listen: 12345
---- tcp_query eval_stdout
-# Note: The incoming request contains CRLF line endings and print needs to
-# be used here to get the same line breaks to the expected request
-print "CONNECT 127.0.0.1:443 HTTP/1.1\r\nUser-Agent: test_ua\r\nHost: 127.0.0.1:443\r\n\r\n"
+--- tcp_query eval
+qr/CONNECT 127.0.0.1:443 HTTP\/1.1\r\n.*Host: 127.0.0.1:443\r\n.*/s
 
 # The reply cannot be successful or otherwise the client would start
 # to do a TLS handshake with the proxied host and that we cannot

--- a/t/16-http-proxy.t
+++ b/t/16-http-proxy.t
@@ -1,0 +1,247 @@
+use Test::Nginx::Socket;
+use Cwd qw(cwd);
+
+plan tests => repeat_each() * (blocks() * 4);
+
+my $pwd = cwd();
+
+$ENV{TEST_NGINX_RESOLVER} = '8.8.8.8';
+$ENV{TEST_NGINX_PWD} ||= $pwd;
+$ENV{TEST_COVERAGE} ||= 0;
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;/usr/local/share/lua/5.1/?.lua;;";
+    error_log logs/error.log debug;
+    resolver 8.8.8.8;
+
+    init_by_lua_block {
+        if $ENV{TEST_COVERAGE} == 1 then
+            jit.off()
+            require("luacov.runner").init()
+        end
+    }
+};
+
+no_long_string();
+run_tests();
+
+__DATA__
+=== TEST 1: get_proxy_uri returns nil if proxy is not configured
+--- http_config eval: $::HttpConfig
+--- config
+    location /lua {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            ngx.say(httpc:get_proxy_uri("http", "example.com"))
+        }
+    }
+--- request
+GET /lua
+--- response_body
+nil
+--- no_error_log
+[error]
+[warn]
+
+=== TEST 2: get_proxy_uri matches no_proxy hosts correctly
+--- http_config eval: $::HttpConfig
+--- config
+    location /lua {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+
+            -- helper that verifies get_proxy_uri works correctly with the given
+            -- scheme, host and no_proxy list
+            function test_no_proxy(scheme, host, no_proxy)
+                httpc:set_proxy_options({
+                    http_proxy = "http://http_proxy.example.com",
+                    https_proxy = "http://https_proxy.example.com",
+                    no_proxy = no_proxy
+                })
+
+                local proxy_uri = httpc:get_proxy_uri(scheme, host)
+                ngx.say("scheme: ", scheme, ", host: ", host, ", no_proxy: ", no_proxy, ", proxy_uri: ", proxy_uri)
+            end
+
+            -- All these match the no_proxy list
+            test_no_proxy("http", "example.com", nil)
+            test_no_proxy("http", "example.com", "*")
+            test_no_proxy("http", "example.com", "example.com")
+            test_no_proxy("http", "sub.example.com", "example.com")
+            test_no_proxy("http", "example.com", "example.com,example.org")
+            test_no_proxy("http", "example.com", "example.org,example.com")
+
+            -- Same for https for good measure
+            test_no_proxy("https", "example.com", nil)
+            test_no_proxy("https", "example.com", "*")
+            test_no_proxy("https", "example.com", "example.com")
+            test_no_proxy("https", "sub.example.com", "example.com")
+            test_no_proxy("https", "example.com", "example.com,example.org")
+            test_no_proxy("https", "example.com", "example.org,example.com")
+
+            -- Edge cases
+
+            -- example.com should match .example.com in the no_proxy list (legacy behavior of wget)
+            test_no_proxy("http", "example.com", ".example.com")
+
+            -- notexample.com should not match example.com in the no_proxy list (not a subdomain)
+            test_no_proxy("http", "notexample.com", "example.com")
+         }
+    }
+--- request
+GET /lua
+--- response_body
+scheme: http, host: example.com, no_proxy: nil, proxy_uri: http://http_proxy.example.com
+scheme: http, host: example.com, no_proxy: *, proxy_uri: nil
+scheme: http, host: example.com, no_proxy: example.com, proxy_uri: nil
+scheme: http, host: sub.example.com, no_proxy: example.com, proxy_uri: nil
+scheme: http, host: example.com, no_proxy: example.com,example.org, proxy_uri: nil
+scheme: http, host: example.com, no_proxy: example.org,example.com, proxy_uri: nil
+scheme: https, host: example.com, no_proxy: nil, proxy_uri: http://https_proxy.example.com
+scheme: https, host: example.com, no_proxy: *, proxy_uri: nil
+scheme: https, host: example.com, no_proxy: example.com, proxy_uri: nil
+scheme: https, host: sub.example.com, no_proxy: example.com, proxy_uri: nil
+scheme: https, host: example.com, no_proxy: example.com,example.org, proxy_uri: nil
+scheme: https, host: example.com, no_proxy: example.org,example.com, proxy_uri: nil
+scheme: http, host: example.com, no_proxy: .example.com, proxy_uri: nil
+scheme: http, host: notexample.com, no_proxy: example.com, proxy_uri: http://http_proxy.example.com
+--- no_error_log
+[error]
+[warn]
+
+=== TEST 3: get_proxy_uri returns correct proxy URIs for http and https URIs
+--- http_config eval: $::HttpConfig
+--- config
+    location /lua {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+
+            -- helper that configures the proxy opts as proived and checks what
+            -- get_proxy_uri says for the given scheme / host pair
+            function test_get_proxy_uri(scheme, host, http_proxy, https_proxy)
+                httpc:set_proxy_options({
+                    http_proxy = http_proxy,
+                    https_proxy = https_proxy
+                })
+
+                local proxy_uri = httpc:get_proxy_uri(scheme, host)
+                ngx.say(
+                    "scheme: ", scheme,
+                    ", host: ", host,
+                    ", http_proxy: ", http_proxy,
+                    ", https_proxy: ", https_proxy,
+                    ", proxy_uri: ", proxy_uri
+                )
+            end
+
+            -- http
+            test_get_proxy_uri("http", "example.com", "http_proxy", "https_proxy")
+            test_get_proxy_uri("http", "example.com", nil, "https_proxy")
+
+            -- https
+            test_get_proxy_uri("https", "example.com", "http_proxy", "https_proxy")
+            test_get_proxy_uri("https", "example.com", "http_proxy", nil)
+        }
+    }
+--- request
+GET /lua
+--- response_body
+scheme: http, host: example.com, http_proxy: http_proxy, https_proxy: https_proxy, proxy_uri: http_proxy
+scheme: http, host: example.com, http_proxy: nil, https_proxy: https_proxy, proxy_uri: nil
+scheme: https, host: example.com, http_proxy: http_proxy, https_proxy: https_proxy, proxy_uri: https_proxy
+scheme: https, host: example.com, http_proxy: http_proxy, https_proxy: nil, proxy_uri: nil
+--- no_error_log
+[error]
+[warn]
+
+=== TEST 4: request_uri uses http_proxy correctly for non-standard destination ports
+--- http_config
+    lua_package_path "$TEST_NGINX_PWD/lib/?.lua;;";
+    error_log logs/error.log debug;
+    resolver 8.8.8.8;
+    server {
+        listen *:8080;
+
+        location / {
+            content_by_lua_block {
+                ngx.print(ngx.req.raw_header())
+            }
+        }
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:set_proxy_options({
+                http_proxy = "http://127.0.0.1:8080",
+                https_proxy = "http://127.0.0.1:8080"
+            })
+
+            -- request should go to the proxy server
+            local res, err = httpc:request_uri("http://127.0.0.1:1234/target?a=1&b=2")
+
+            if not res then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+            ngx.status = res.status
+            ngx.say(res.body)
+        }
+    }
+--- request
+GET /lua
+--- response_body_like
+^GET http://127.0.0.1:1234/target\?a=1&b=2 HTTP/.+\r\nHost: 127.0.0.1:1234.+
+--- no_error_log
+[error]
+[warn]
+
+=== TEST 5: request_uri uses http_proxy correctly for standard destination port
+--- http_config
+    lua_package_path "$TEST_NGINX_PWD/lib/?.lua;;";
+    error_log logs/error.log debug;
+    resolver 8.8.8.8;
+    server {
+        listen *:8080;
+
+        location / {
+            content_by_lua_block {
+                ngx.print(ngx.req.raw_header())
+            }
+        }
+    }
+--- config
+    location /lua {
+        content_by_lua_block {
+            local http = require "resty.http"
+            local httpc = http.new()
+            httpc:set_proxy_options({
+                http_proxy = "http://127.0.0.1:8080",
+                https_proxy = "http://127.0.0.1:8080"
+            })
+
+            -- request should go to the proxy server
+            local res, err = httpc:request_uri("http://127.0.0.1/target?a=1&b=2")
+
+            if not res then
+                ngx.log(ngx.ERR, err)
+                return
+            end
+
+            -- the proxy echoed the raw request header and we shall pass it onwards
+            -- to the test harness
+            ngx.status = res.status
+            ngx.say(res.body)
+        }
+    }
+--- request
+GET /lua
+--- response_body_like
+^GET http://127.0.0.1/target\?a=1&b=2 HTTP/.+\r\nHost: 127.0.0.1.+
+--- no_error_log
+[error]
+[warn]


### PR DESCRIPTION
These changes introduce support for making HTTP requests through a
forward proxy when using the high-level request_uri() API.

The new set_proxy_options() function can be used to configure HTTP proxy
settings. This method takes a table as a parameter that can include the
following fields:
* http_proxy - an URI to a proxy that should be used for http:// requests
* https_proxy - an URI to a proxy that should be used for https:// requests
* no_proxy - a comma separated list of hosts / IPs that should not go through
  the configured proxy

When request_uri() is called with an http:// URI and http_proxy has been
configured for the client instance, the connection will be established to
the proxy host. Once the connection has been established, the HTTP request
is sent to the proxy host as if the peer on the other end of the connection
was the remote server. The only difference to the non-proxy case is that
the path sent to the proxy is actually a full URI instead of a relative
path.

When request_uri() is called with an https:// URI and https_proxy has been
configured for the client instance, the connection will be established to
the proxy host. Once the connection has been established, we go ahead and
perform a CONNECT request to open a TCP tunnel to the remote server. If
the proxy gives a success response, to the CONNECT request, the client
continues to perform the TLS handshake with the remote server and making
the request as if there was no proxy configured.

Some tests have been included which verify that the proxy options are
interpreted correctly in different cases and that http_proxy works as
real proxies expect. This is about as much there is to test without
actually including a real forward proxy in the test harness. Manual
testing has been performed against squid and tinyproxy.

Fixes #63