### PR TITLE
fix: request_uri error leaves socket open

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -818,11 +818,13 @@ function _M.request_uri(self, uri, params)
 
     local res, err = self:request(params)
     if not res then
+        self:close()
         return nil, err
     end
 
     local body, err = res:read_body()
     if not body then
+        self:close()
         return nil, err
     end
 


### PR DESCRIPTION
For example, if a request times-out, the response may still be received
because the socket is not closed and the next request using the socket
will read the timed-out request's response and result in a "unread data
in buffer" error from set_keepalive.