### PR TITLE
feat: request_uri() keepalive params

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ server {
         body = "a=1&b=2",
         headers = {
           ["Content-Type"] = "application/x-www-form-urlencoded",
-        }
+        },
+        keepalive_opts = {10000, 10}
       })
 
       if not res then
@@ -273,7 +274,7 @@ When the request is successful, `res` will contain the following fields:
 
 `syntax: res, err = httpc:request_uri(uri, params)`
 
-The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself.
+The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself, and you can set keepalive options with `keepalive_opts`.
 
 In this mode, there is no need to connect manually first. The connection is made on your behalf, suiting cases where you simply need to grab a URI without too much hassle.
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ server {
         headers = {
           ["Content-Type"] = "application/x-www-form-urlencoded",
         },
-        keepalive_opts = {10000, 10}
+        keepalive_timeout = 60,
+        keepalive_pool = 10
       })
 
       if not res then
@@ -274,7 +275,10 @@ When the request is successful, `res` will contain the following fields:
 
 `syntax: res, err = httpc:request_uri(uri, params)`
 
-The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself, and you can set keepalive options with `keepalive_opts`.
+The simple interface. Options supplied in the `params` table are the same as in the generic interface, and will override components found in the uri itself, Moreover you can set keepalive options with to fileds:
+
+* `keepalive_timeout` A value for tcpsock:setkeepalive (default is 0), Set `-1` to close connection immediately.
+* `keepalive_pool` A value for tcpsock:setkeepalive (default is lua_socket_pool_size).
 
 In this mode, there is no need to connect manually first. The connection is made on your behalf, suiting cases where you simply need to grab a URI without too much hassle.
 

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -873,9 +873,21 @@ function _M.request_uri(self, uri, params)
 
     res.body = body
 
-    local ok, err = self:set_keepalive()
-    if not ok then
-        ngx_log(ngx_ERR, err)
+    if params.keepalive_opts == nil then
+        local ok, err = self:set_keepalive()
+        if not ok then
+            ngx_log(ngx_ERR, err)
+        end
+    elseif params.keepalive_opts == false then
+        local ok, err = self:close()
+        if not ok then
+            ngx_log(ngx_ERR, err)
+        end
+    else
+        local ok, err = self:set_keepalive(unpack(params.keepalive_opts))
+        if not ok then
+            ngx_log(ngx_ERR, err)
+        end
     end
 
     return res, nil

--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -873,21 +873,31 @@ function _M.request_uri(self, uri, params)
 
     res.body = body
 
-    if params.keepalive_opts == nil then
-        local ok, err = self:set_keepalive()
-        if not ok then
-            ngx_log(ngx_ERR, err)
-        end
-    elseif params.keepalive_opts == false then
-        local ok, err = self:close()
-        if not ok then
-            ngx_log(ngx_ERR, err)
-        end
+    local ok, err
+    if params.keepalive_timeout == nil then
+      ok, err = self:set_keepalive()
+      if not ok then
+          ngx_log(ngx_ERR, err)
+      end
     else
-        local ok, err = self:set_keepalive(unpack(params.keepalive_opts))
+      if params.keepalive_timeout == -1 then
+        ok, err = self:close()
         if not ok then
             ngx_log(ngx_ERR, err)
         end
+      else
+        if params.keepalive_pool then
+          ok, err = self:set_keepalive(params.keepalive_timeout, params.keepalive_pool)
+          if not ok then
+              ngx_log(ngx_ERR, err)
+          end
+        else
+          ok, err = self:set_keepalive(params.keepalive_timeout)
+          if not ok then
+              ngx_log(ngx_ERR, err)
+          end
+        end
+      end
     end
 
     return res, nil


### PR DESCRIPTION
We can set keepalive_opts like
```
      local res, err = httpc:request_uri("http://api.m.taobao.com/rest/api3.do?api=mtop.common.getTimestamp", {
        ssl_verify = false,
        keepalive_opts = {10000, 10}
    })
```