### PR TITLE
Allow empty HTTP header values

### DIFF
--- a/lib/resty/http.lua
+++ b/lib/resty/http.lua
@@ -338,7 +338,7 @@ local function _receive_headers(sock)
             return nil, err
         end
 
-        local m, err = ngx_re_match(line, "([^:\\s]+):\\s*(.+)", "jo")
+        local m, err = ngx_re_match(line, "([^:\\s]+):\\s*(.*)", "jo")
         if not m then
             break
         end


### PR DESCRIPTION
According to [RFC7230](https://tools.ietf.org/html/rfc7230) an empty `field-value` is acceptable due to the `*()` rule, see:
```
field-value    = *( field-content / obs-fold )
field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
```

Resolves #118.