### PR TITLE
Add chunk size as return value to the body reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ server {
       local reader = res.body_reader
 
       repeat
-        local chunk, err = reader(8192)
+        local chunk, err, chunk_size = reader(8192)
         if err then
           ngx.log(ngx.ERR, err)
           break
@@ -327,7 +327,7 @@ The `body_reader` iterator can be used to stream the response body in chunk size
 local reader = res.body_reader
 
 repeat
-  local chunk, err = reader(8192)
+  local chunk, err, chunk_size = reader(8192)
   if err then
     ngx.log(ngx.ERR, err)
     break
@@ -339,9 +339,11 @@ repeat
 until not chunk
 ````
 
-If the reader is called with no arguments, the behaviour depends on the type of connection. If the response is encoded as chunked, then the iterator will return the chunks as they arrive. If not, it will simply return the entire body.
+If the reader is called without arguments, the behavior depends on the type of connection. If the response is encoded as chunked, then the iterator will return the chunks as they arrive. If not, it will simply return the entire body.
 
 Note that the size provided is actually a **maximum** size. So in the chunked transfer case, you may get chunks smaller than the size you ask, as a remainder of the actual HTTP chunks.
+
+As of version `0.13`, a third return value was added, which indicates the size of the chunk. This value is `nil` when the reader is called without arguments and the response is **not** encoded as chunked.
 
 ## res:read_body
 

--- a/t/02-chunked.t
+++ b/t/02-chunked.t
@@ -79,10 +79,12 @@ GET /a
             }
 
             local chunks = {}
+            local sizes = {}
             local c = 1
             repeat
-                local chunk, err = res.body_reader()
+                local chunk, err, chunk_size = res.body_reader()
                 if chunk then
+                    sizes[c] = chunk_size
                     chunks[c] = chunk
                     c = c + 1
                 end
@@ -90,6 +92,7 @@ GET /a
 
             local body = table.concat(chunks)
 
+            ngx.say(table.concat(sizes, "\\n"))
             ngx.say(#body)
             ngx.say(#chunks)
             httpc:close()
@@ -114,6 +117,8 @@ GET /a
 --- request
 GET /a
 --- response_body
+32768
+32768
 65536
 2
 --- no_error_log

--- a/t/05-stream.t
+++ b/t/05-stream.t
@@ -40,15 +40,18 @@ __DATA__
             }
 
             local chunks = {}
+            local total_size = 0
             repeat
-                local chunk = res.body_reader()
+                local chunk, _, chunk_size = res.body_reader()
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
             until not chunk
 
             local body = table.concat(chunks)
             ngx.say(#body)
+            ngx.say(total_size)
             ngx.say(res.headers["Transfer-Encoding"])
 
             httpc:close()
@@ -67,6 +70,7 @@ __DATA__
 --- request
 GET /a
 --- response_body
+32768
 32768
 chunked
 --- no_error_log
@@ -89,9 +93,10 @@ chunked
 
             local chunks = {}
             repeat
-                local chunk = res.body_reader()
+                local chunk, _, chunk_size = res.body_reader()
                 if chunk then
                     table.insert(chunks, chunk)
+                    assert(chunk_size == nil, "chunk size should be nil")
                 end
             until not chunk
 
@@ -139,17 +144,20 @@ nil
             }
 
             local chunks = {}
+            local total_size = 0
             local buffer_size = 16384
             repeat
-                local chunk = res.body_reader(buffer_size)
+                local chunk, _, chunk_size = res.body_reader(buffer_size)
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
 
                 buffer_size = nil
             until not chunk
 
             local body = table.concat(chunks)
+            ngx.say(total_size)
             ngx.say(res.headers["Transfer-Encoding"])
 
             httpc:close()
@@ -169,6 +177,7 @@ nil
 --- request
 GET /a
 --- response_body
+16384
 nil
 --- error_log
 Buffer size not specified, bailing
@@ -189,15 +198,18 @@ Buffer size not specified, bailing
             }
 
             local chunks = {}
+            local total_size = 0
             repeat
-                local chunk = res.body_reader()
+                local chunk, _, chunk_size = res.body_reader()
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
             until not chunk
 
             local body = table.concat(chunks)
             ngx.say(#body)
+            ngx.say(total_size)
             ngx.say(res.headers["Transfer-Encoding"])
             ngx.say(#chunks)
 
@@ -218,6 +230,7 @@ Buffer size not specified, bailing
 --- request
 GET /a
 --- response_body
+32768
 32768
 nil
 1
@@ -241,17 +254,20 @@ nil
             }
 
             local chunks = {}
+            local total_size = 0
             local size = 8192
             repeat
-                local chunk = res.body_reader(size)
+                local chunk, _, chunk_size = res.body_reader(size)
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
                 size = size + size
             until not chunk
 
             local body = table.concat(chunks)
             ngx.say(#body)
+            ngx.say(total_size)
             ngx.say(res.headers["Transfer-Encoding"])
             ngx.say(#chunks)
 
@@ -272,6 +288,7 @@ nil
 --- request
 GET /a
 --- response_body
+32769
 32769
 nil
 3
@@ -295,17 +312,20 @@ nil
             }
 
             local chunks = {}
+            local total_size = 0
             local size = 8192
             repeat
-                local chunk = res.body_reader(size)
+                local chunk, _, chunk_size = res.body_reader(size)
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
                 size = size + size
             until not chunk
 
             local body = table.concat(chunks)
             ngx.say(#body)
+            ngx.say(total_size)
             ngx.say(#chunks)
 
             httpc:close()
@@ -337,6 +357,7 @@ nil
 GET /a
 --- response_body
 32769
+32769
 3
 --- no_error_log
 [error]
@@ -357,17 +378,20 @@ GET /a
             }
 
             local chunks = {}
+            local total_size = 0
             local size = 8192
             repeat
-                local chunk = res.body_reader(size)
+                local chunk, _, chunk_size = res.body_reader(size)
                 if chunk then
                     table.insert(chunks, chunk)
+                    total_size = total_size + chunk_size
                 end
                 size = size + size
             until not chunk
 
             local body = table.concat(chunks)
             ngx.say(#body)
+            ngx.say(total_size)
             ngx.say(res.headers["Transfer-Encoding"])
             ngx.say(#chunks)
 
@@ -387,6 +411,7 @@ GET /a
 --- request
 GET /a
 --- response_body
+32768
 32768
 chunked
 3


### PR DESCRIPTION
Can be useful in determining the size of the body while the chunks are being read. For example, to check if the body is too large to process.

I added this return value for performance reasons. In the past, the only way to determine the chunk size is to use `string.len()` or `#` on the chunk.

To keep backwards compatibility the return value was added as third. Unit tests have been changed correctly to integrate this new return value.